### PR TITLE
Update __init__.py

### DIFF
--- a/german_nouns/lookup/__init__.py
+++ b/german_nouns/lookup/__init__.py
@@ -20,7 +20,7 @@ class WordSlice(TypedDict):
 class Nouns(object):
     def __init__(self) -> None:
         # parse csv file
-        data = list(csv.reader(open(CSV_FILE_PATH)))
+        data = list(csv.reader(open(CSV_FILE_PATH, encoding="utf-8"))
         self.header = data[0]
         self.data = data[1:]
 


### PR DESCRIPTION
fixes the file read operation by specifying encoding

The csv file contains characters that are utf-encoded and Python's open function throws an error if the encoding is not specified.